### PR TITLE
JIRA API 기능에 전략패턴 및 팩토리패턴 추가

### DIFF
--- a/server/src/main/java/com/e203/global/utils/ExceptionHandler.java
+++ b/server/src/main/java/com/e203/global/utils/ExceptionHandler.java
@@ -1,0 +1,11 @@
+package com.e203.global.utils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ExceptionHandler {
+
+    static public void handleException(String message, Exception e) {
+        log.error(message, e);
+    }
+}

--- a/server/src/main/java/com/e203/project/factory/JiraResponseProcessorFactory.java
+++ b/server/src/main/java/com/e203/project/factory/JiraResponseProcessorFactory.java
@@ -1,0 +1,18 @@
+package com.e203.project.factory;
+
+import com.e203.project.dto.jiraapi.JiraResponse;
+import com.e203.project.dto.jiraapi.JiraSprintFindIssue;
+import com.e203.project.strategy.IssueResponseProcessor;
+import com.e203.project.strategy.JiraResponseProcessor;
+import com.e203.project.strategy.JiraSprintResponseProcessor;
+
+public class JiraResponseProcessorFactory {
+    public static <T, R> JiraResponseProcessor<T,R> getProcessor(Class<T> responseType) {
+        if (responseType.equals(JiraSprintFindIssue.class)) {
+            return (JiraResponseProcessor<T,R>) new JiraSprintResponseProcessor();
+        } else if (responseType.equals(JiraResponse.class)) {
+            return (JiraResponseProcessor<T,R>) new IssueResponseProcessor();
+        }
+        throw new IllegalArgumentException("Unsupported response type: " + responseType.getName());
+    }
+}

--- a/server/src/main/java/com/e203/project/strategy/Data.java
+++ b/server/src/main/java/com/e203/project/strategy/Data.java
@@ -1,0 +1,21 @@
+package com.e203.project.strategy;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Data {
+    private final String JIRA_URL = "https://ssafy.atlassian.net/rest";
+    private String jql;
+    private String fields;
+    private String key;
+
+    @Builder
+    public Data(String jql, String fields, String key){
+        this.jql = jql;
+        this.fields = fields;
+        this.key = key;
+    }
+}

--- a/server/src/main/java/com/e203/project/strategy/IssueResponseProcessor.java
+++ b/server/src/main/java/com/e203/project/strategy/IssueResponseProcessor.java
@@ -1,0 +1,14 @@
+package com.e203.project.strategy;
+
+import com.e203.project.dto.jiraapi.JiraContent;
+import com.e203.project.dto.jiraapi.JiraResponse;
+import java.util.List;
+
+public class IssueResponseProcessor implements JiraResponseProcessor<JiraResponse, JiraContent> {
+
+    @Override
+    public Pagination processResponse(JiraResponse response, List<JiraContent> issues) {
+        issues.addAll(response.getIssues());
+        return new Pagination(response.getIssues().size(), response.getTotal());
+    }
+}

--- a/server/src/main/java/com/e203/project/strategy/JiraApiFindStrategy.java
+++ b/server/src/main/java/com/e203/project/strategy/JiraApiFindStrategy.java
@@ -1,0 +1,51 @@
+package com.e203.project.strategy;
+
+import com.e203.global.utils.ExceptionHandler;
+import com.e203.project.factory.JiraResponseProcessorFactory;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+@Component
+@RequiredArgsConstructor
+public class JiraApiFindStrategy<T> implements JiraApiStrategy<Data, T> {
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+    @Override
+    public T execute(Data data, Class<T> responseType) {
+        List<T> issues = new ArrayList<>();
+        int startAt = 0;
+        int maxResults = 100;
+        boolean hasMore = true;
+
+        JiraResponseProcessor processor = JiraResponseProcessorFactory.getProcessor(responseType);
+
+        while (hasMore) {
+            String jiraUri = data.getJIRA_URL() + data.getJql() + data.getFields() + "&startAt=" + startAt + "&maxResults=" + maxResults;
+            try {
+                String responseBody = getRequestString(jiraUri, data.getKey());
+                T response = objectMapper.readValue(responseBody, new TypeReference<T>() {});
+                Pagination pagination= processor.processResponse(response, issues);
+
+                startAt += pagination.getNext();
+                hasMore = startAt < pagination.getTotal();
+            } catch (Exception e) {
+                ExceptionHandler.handleException("Error occurred while calling Jira API", e);
+                break;
+            }
+        }
+        return (T) issues;
+    }
+
+    private String getRequestString(String jiraUri, String encodedCredentials) {
+        return restClient.get()
+                .uri(jiraUri)
+                .header("Authorization", "Basic " + encodedCredentials)
+                .header("Content-Type", "application/json")
+                .retrieve()
+                .body(String.class);
+    }
+}

--- a/server/src/main/java/com/e203/project/strategy/JiraApiStrategy.java
+++ b/server/src/main/java/com/e203/project/strategy/JiraApiStrategy.java
@@ -1,0 +1,7 @@
+package com.e203.project.strategy;
+
+import java.util.List;
+
+public interface JiraApiStrategy<T, R> {
+    R execute(T request, Class<R> responseType);
+}

--- a/server/src/main/java/com/e203/project/strategy/JiraResponseProcessor.java
+++ b/server/src/main/java/com/e203/project/strategy/JiraResponseProcessor.java
@@ -1,0 +1,7 @@
+package com.e203.project.strategy;
+
+import java.util.List;
+
+public interface JiraResponseProcessor<T, R> {
+    Pagination processResponse(T response, List<R> issues);
+}

--- a/server/src/main/java/com/e203/project/strategy/JiraSprintResponseProcessor.java
+++ b/server/src/main/java/com/e203/project/strategy/JiraSprintResponseProcessor.java
@@ -1,0 +1,14 @@
+package com.e203.project.strategy;
+
+import com.e203.project.dto.jiraapi.JiraSprintFindIssue;
+import com.e203.project.dto.jiraapi.JiraSprintFindIssueRequest;
+import java.util.List;
+
+public class JiraSprintResponseProcessor implements JiraResponseProcessor<JiraSprintFindIssue, JiraSprintFindIssueRequest> {
+
+    @Override
+    public Pagination processResponse(JiraSprintFindIssue response, List<JiraSprintFindIssueRequest> issues) {
+        issues.addAll(response.getIssues());
+        return new Pagination(response.getIssues().size(), response.getTotal());
+    }
+}

--- a/server/src/main/java/com/e203/project/strategy/Pagination.java
+++ b/server/src/main/java/com/e203/project/strategy/Pagination.java
@@ -1,0 +1,17 @@
+package com.e203.project.strategy;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Pagination {
+    private int next;
+    private int total;
+
+    @Builder
+    public Pagination(int next, int total){
+        this.next = next;
+        this.total =total;
+    }
+
+}


### PR DESCRIPTION
문제: 
- Sprint 생성, Jira 생성에 대한 Response 객체와 요청Dto가 상이하여, 비즈니스 로직 내부에서 if-else를 사용하여 처리하고 있음. 

해결: 
- 전략 패턴을 사용하여 서로 다른 Response 타입을 갖는 각 기능들을 비즈니스 로직에서 떼어냄
- 팩토리 패턴을 사용하여 사용하고자 하는 기능에 따라 알맞은 전략 객체가 리턴되도록 함 